### PR TITLE
fix: Font changes now properly reflect on canvas text

### DIFF
--- a/src/app/card-creator/services/canvas.service.ts
+++ b/src/app/card-creator/services/canvas.service.ts
@@ -153,7 +153,10 @@ export class CanvasService {
         const activeObject = this.canvas?.getActiveObject();
         if (activeObject && activeObject instanceof fabric.IText) {
             activeObject.set(options);
-            this.canvas?.renderAll();
+            // Mark as dirty to force re-render and recalculate dimensions
+            activeObject.dirty = true;
+            activeObject.setCoords();
+            this.canvas?.requestRenderAll();
         }
     }
 


### PR DESCRIPTION
- Mark text object as dirty after property changes
- Call setCoords() to recalculate bounding box
- Use requestRenderAll() for proper re-rendering