### PR TITLE
fix: correct Google Fonts CSS2 API URL format for font loading

### DIFF
--- a/src/app/card-creator/card-creator.component.ts
+++ b/src/app/card-creator/card-creator.component.ts
@@ -211,9 +211,12 @@ export class CardCreatorComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     private loadGoogleFonts(): void {
-        const fonts = this.fonts.join('|').replace(/ /g, '+');
+        // CSS2 API requires separate family= parameters for each font
+        const fontParams = this.fonts
+            .map(font => `family=${font.replace(/ /g, '+')}:wght@300;400;500;600;700`)
+            .join('&');
         const link = document.createElement('link');
-        link.href = `https://fonts.googleapis.com/css2?family=${fonts}:wght@300;400;500;600;700&display=swap`;
+        link.href = `https://fonts.googleapis.com/css2?${fontParams}&display=swap`;
         link.rel = 'stylesheet';
         document.head.appendChild(link);
     }


### PR DESCRIPTION
- Changed from pipe-separated fonts (CSS v1) to separate family= params (CSS2)
- Fonts now load correctly and can be applied to canvas text elements