### PR TITLE
fix: conditionally display ads only when content is available

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -73,8 +73,8 @@
       <p>{{ 'HOME.CARDS.ABOUT_DESC_2' | translate }}</p>
     </div>
 
-    <!-- Ad Unit -->
-    <div class="card centered">
+    <!-- Ad Unit - only show when content is available -->
+    <div class="card centered" *ngIf="githubStats">
       <small class="muted">{{ 'COMMON.SPONSORED' | translate }}</small>
       <app-ad-unit adSlot="1234567890"></app-ad-unit>
     </div>
@@ -82,8 +82,8 @@
     <!-- Legal Links for Compliance -->
     <div class="legal-links-section">
       <p class="legal-text">
-        By using this site, you agree to our 
-        <a routerLink="/privacy">Privacy Policy</a> and 
+        By using this site, you agree to our
+        <a routerLink="/privacy">Privacy Policy</a> and
         <a routerLink="/terms">Terms of Service</a>.
       </p>
     </div>

--- a/src/app/kavithai/kavithai.component.html
+++ b/src/app/kavithai/kavithai.component.html
@@ -27,11 +27,13 @@
             </div>
 
             <div class="grid-layout">
-                <!-- Top Ad -->
+                <!-- Top Ad - only show when content is available -->
+                @if ((kavithaigal$ | async)?.length) {
                 <div class="card centered">
                     <small class="muted">{{ 'COMMON.SPONSORED' | translate }}</small>
                     <app-ad-unit adSlot="1234567890"></app-ad-unit>
                 </div>
+                }
 
                 @if (errorMessage) {
                 <div class="error-state">
@@ -94,11 +96,13 @@
                 }
                 }
 
-                <!-- Bottom Ad -->
+                <!-- Bottom Ad - only show when content is available -->
+                @if ((kavithaigal$ | async)?.length) {
                 <div class="card centered">
                     <small class="muted">{{ 'COMMON.SPONSORED' | translate }}</small>
                     <app-ad-unit adSlot="1234567890"></app-ad-unit>
                 </div>
+                }
             </div>
         </div>
 

--- a/src/app/news/news.component.ts
+++ b/src/app/news/news.component.ts
@@ -107,8 +107,8 @@ import { AdUnitComponent } from '../shared/ad-unit/ad-unit.component';
           </div>
         </ng-template>
 
-        <!-- Bottom Ad -->
-        <div class="card centered ad-card">
+        <!-- Bottom Ad - only show when content is available -->
+        <div class="card centered ad-card" *ngIf="articles.length > 0">
           <small class="muted">{{ 'COMMON.SPONSORED' | translate }}</small>
           <app-ad-unit adSlot="1234567890"></app-ad-unit>
         </div>


### PR DESCRIPTION
AdSense policy compliance fix - ads no longer show on loading/empty screens:
- kavithai: top and bottom ads only show when poems are loaded
- news: bottom ad only shows when articles exist
- home: ad only shows after GitHub stats load